### PR TITLE
bugfix: User email address matching to be case insensitive

### DIFF
--- a/nexus_auth/views.py
+++ b/nexus_auth/views.py
@@ -95,7 +95,8 @@ class OAuthExchangeView(APIView):
         if not email:
             raise MissingEmailFromProviderError()
         try:
-            user = User.objects.get(email=email)
+            # Match the email case-insensitively
+            user = User.objects.get(email__iexact=email)
         except User.DoesNotExist as e:
             raise NoAssociatedUserError() from e
 


### PR DESCRIPTION
## Context 

Email addresses returned from the Identity Providers may contain different letter-casing (uppercase, lowercase letters). For instance, Microsoft Graph API returns the originally set email address in a case-sensitive matter.

## Problem

This is a problem when we perform a look-up in the database to get the matching user. 

Given: User with email in database (test@example.com)
When:
`User.objects.get(email=Test@example.com) # This will raise DoesNotExist `

# Solution

The solution is to use case insensitive matching when doing the User lookup via email.